### PR TITLE
Fix-preTrialPosn

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ or after the last one
 `triggers`: [Optional] A list or single key that needs to be pressed to start the session after the experimenter has manually
 started it. This is useful when there's an external devices that needs to synchronize execution, such as an MRI scanner.
 If the parameter is missing, the session will start as soon as the experimenter clicks on start  
-`colours`: [Optional] A hex colour code (without '#') to use for the `leftReference`, `leftForce`, `rightReference` or `rightForce` bars  
+`colours`: [Optional] A hex colour code (without '#') to use for the `leftReference`, `leftForce`, `rightReference` or `rightForce` bars
+```
+  colours: # optional
+    leftReference: 0000FF #blue
+    leftForce: FEFE00 #yellow
+```
+
 `blocks`: The list of blocks in the sessions  
 `blocks.name`: A friendly name of a particular block. Seen only by the experimenter  
 `blocks.instructions`: A string giving the instructions to the participant of the block that is about to start  

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.neuralabc.spft</groupId>
     <artifactId>spft</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.5-SNAPSHOT</version>
     <name>Sequence Pinch Force Task</name>
     <description>A Java implementation of a Sequence Pinch Force task, with ability to trigger to external serial device</description>
 

--- a/src/main/java/com/github/neuralabc/spft/task/Block.java
+++ b/src/main/java/com/github/neuralabc/spft/task/Block.java
@@ -31,12 +31,19 @@ public class Block {
     public void run(ExperimentFrame.Binding binding, Path outputFile) throws InterruptedException, IOException {
         LOG.info("\tStarting block '{}'", config.getName());
 
+        // set the position of the bars back to 0 (which will be equivalent to min height)
+        // at the start of every block to ensure that the participant does not move
+        // to the last position of the previous trial (and b/c this is set to 1 on the 1st block)
+        binding.setLeftReferenceValue(0.0); // testing
+        binding.setRightReferenceValue(0.0); // testing
+        
         binding.showLeftBars(trials.get(0).hasLeftSequence());
         binding.showRightBars(trials.get(0).hasRightSequence());
+
         binding.showText(config.getInstructions());
+        
         Thread.sleep(config.getInstructionsDuration());
         binding.showText("");
-
         for (int currentTrial = 0; currentTrial < config.getTrials().size(); currentTrial++) {
             Trial nextTrial = trials.get(currentTrial);
 

--- a/src/main/java/com/github/neuralabc/spft/task/Trial.java
+++ b/src/main/java/com/github/neuralabc/spft/task/Trial.java
@@ -66,6 +66,12 @@ public class Trial {
         
         timer.stop();
         writeOutput(outputFile);
+
+        // at the end of every trial we also reset the reference values to the min value
+        // to indicate the trial has ended and ensure that the participant does not move
+        // to the last position of the previous trial
+        binding.setLeftReferenceValue(0.0);
+        binding.setRightReferenceValue(0.0);
     }
 
     private void writeOutput(Path outputFile) throws IOException {


### PR DESCRIPTION
reset reference bar heights to 0 prior to the start of the first block and at the end of each trial to fix issue with initial height on first block and maintained display of the last element [height] at the end of the trial 
  - fixes issue #11 